### PR TITLE
Added support for trailing and leading whitespace

### DIFF
--- a/main.less
+++ b/main.less
@@ -23,34 +23,96 @@
  */
 
 .CodeMirror {
-	.cm-dk-whitespace-space, .cm-dk-whitespace-tab {
-		position: relative;
-		&:before {
-			content: "";
-			position: absolute;
-			display: block;
-			height: 0;
-			top: 50%;
-			border-radius: 1ex;
-			height: 0.2ex;
-		}
-	}
-	.cm-dk-whitespace-space:before {
-		left: 50%;
-		width:        0.2ex;
-		margin-left: -0.1ex;
+    .cm-dk-whitespace-space, .cm-dk-whitespace-tab {
+        position: relative;
+        &:before {
+            content: "";
+            position: absolute;
+            display: block;
+            height: 0;
+            top: 50%;
+            border-radius: 1ex;
+            height: 0.2ex;
+        }
+    }
+    .cm-dk-whitespace-space:before {
+        left: 50%;
+        width:        0.2ex;
+        margin-left: -0.1ex;
 
-		min-width:  2px;
-		min-height: 2px;
-	}
-	.cm-dk-whitespace-tab:before {
-		left: 0.2ex;
-		right: 0.2ex;
+        min-width:  2px;
+        min-height: 2px;
+    }
+    .cm-dk-whitespace-tab:before {
+        left: 0.2ex;
+        right: 0.2ex;
 
-		min-width:  2px;
-		min-height: 1px;
-	}
-	.cm-dk-whitespace-space:before, .cm-dk-whitespace-tab:before {
-		background-color: #ccc;
-	}
+        min-width:  2px;
+        min-height: 1px;
+    }
+    .cm-dk-whitespace-space:before, .cm-dk-whitespace-tab:before {
+        background-color: #ccc;
+    }
+    
+    .cm-dk-whitespace-leading-space, .cm-dk-whitespace-leading-tab {
+        position: relative;
+        &:before {
+            content: "";
+            position: absolute;   
+            display: block;
+            height: 0;
+            top: 50%;
+            border-radius: 1ex;
+            height: 0.2ex;
+        }
+    }
+    .cm-dk-whitespace-leading-space:before {
+        left: 50%;
+        width:        0.2ex;
+        margin-left: -0.1ex;
+
+        min-width:  2px;
+        min-height: 2px;
+    }
+    .cm-dk-whitespace-leading-tab:before {
+        left: 0.2ex;
+        right: 0.2ex;
+
+        min-width:  2px;
+        min-height: 1px;
+    }
+    .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-leading-tab:before {
+        background-color: blue;
+    }
+    
+    .cm-dk-whitespace-trailing-space, .cm-dk-whitespace-trailing-tab {
+        position: relative;
+        &:before {
+            content: "";
+            position: absolute;   
+            display: block;
+            height: 0;
+            top: 50%;
+            border-radius: 1ex;
+            height: 0.2ex;
+        }
+    }
+    .cm-dk-whitespace-trailing-space:before {
+        left: 50%;
+        width:        0.2ex;
+        margin-left: -0.1ex;
+
+        min-width:  2px;
+        min-height: 2px;
+    }
+    .cm-dk-whitespace-trailing-tab:before {
+        left: 0.2ex;
+        right: 0.2ex;
+
+        min-width:  2px;
+        min-height: 1px;
+    }
+    .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-trailing-tab:before {
+        background-color: red;
+    }
 }


### PR DESCRIPTION
This adds the token code for leading and trailing white space.

Unfortunately, I am not very experienced with LESS and CSS, so you will probably want to clean up main.less after adding these changes.

FYI, the main.less diff looks like a lot because I ran the tabs to spaces extension on it.

-- Lance.
