### PR TITLE
Support for Brackets Sprint 38+

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, regexp: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, Node, CodeMirror */
+/*global define, $, brackets */
 
 define(function (require, exports, module) {
     "use strict";
@@ -36,6 +36,9 @@ define(function (require, exports, module) {
     var ExtensionUtils     = brackets.getModule("utils/ExtensionUtils");
     var Menus              = brackets.getModule("command/Menus");
     var PreferencesManager = brackets.getModule("preferences/PreferencesManager");
+    
+    // Support for Brackets Sprint 38+ : https://github.com/adobe/brackets/wiki/Brackets-CodeMirror-v4-Migration-Guide
+    var CodeMirror = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror");
 
     
     // --- Settings ---


### PR DESCRIPTION
https://github.com/adobe/brackets/wiki/Brackets-CodeMirror-v4-Migration-Guide

> CodeMirror is no longer global. In Brackets, we used to provide CodeMirror as a global. CodeMirror now supports require(), so we now include CodeMirror as a module instead. This means you should add var CodeMirror = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"); at the top of any module that accesses the CodeMirror object. Sprint 38 will still provide the global CodeMirror (which is the same as the module-loaded CodeMirror), but access to it is deprecated and it will be removed in a future release. (Note that this doesn't affect accesses to editor._codeMirror, which should work as before.)
