### PR TITLE
Turning down the contrast.

### DIFF
--- a/main.less
+++ b/main.less
@@ -51,10 +51,12 @@
         min-height: 1px;
     }
     .cm-dk-whitespace-space:before, .cm-dk-whitespace-tab:before {
-        background-color: #ccc;
+        background-color: #777;
+        opacity: 0.7;
     }
     .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-leading-tab:before {
-        background-color: #ccc;
+        background-color: #777;
+        opacity: 0.7;
     }
     .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-trailing-tab:before {
         background-color: red;


### PR DESCRIPTION
The lines for tabs and the dots for spaces where too bright for all Brackets themes so I toned them down to have less contrast and compared it to SublimeText. If you compare the change to SublimeText you'll notice it's closer to SublimeText's contrast after this change as well. Cheers!
