### PR TITLE
Update use of PreferencesManager to remove deprecation warnings

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
     
     var commandId          = "denniskehrig.ShowWhitespace.toggle";
     var preferencesId      = "denniskehrig.ShowWhitespace";
-    var defaultPreferences = { checked: false };
+    var defaultPreferences = { checked: true };
 
     
     // --- State Variables ---
@@ -277,7 +277,7 @@ define(function (require, exports, module) {
     }
 
     function onCheckedStateChange() {
-        _preferences.setValue("checked", Boolean(_command.getChecked()));
+        _preferences.set("checked", Boolean(_command.getChecked()));
         updateEditors();
     }
     
@@ -289,7 +289,8 @@ define(function (require, exports, module) {
     // --- Loaders and Unloaders ---
 
     function loadPreferences() {
-        _preferences = PreferencesManager.getPreferenceStorage(preferencesId, defaultPreferences);
+        _preferences = PreferencesManager.getExtensionPrefs(preferencesId);
+        _preferences.definePreference("checked", "boolean", defaultPreferences["checked"]);
     }
 
 
@@ -316,7 +317,7 @@ define(function (require, exports, module) {
         $(_command).on("checkedStateChange", onCheckedStateChange);
         
         // Apply preferences
-        _command.setChecked(_preferences.getValue("checked"));
+        _command.setChecked(_preferences.get("checked"));
     }
 
     function unloadCommand() {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "title": "Show Whitespace",
     "description": "Visualizes whitespace similar to how Sublime Text does it",
     "homepage": "https://github.com/DennisKehrig/brackets-show-whitespace",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "author": "Dennis Kehrig <mailgithub@denniskehrig.de> (https://github.com/DennisKehrig)",
     "contributors": [
         "Lance Campbell <lkcampbell@gmail.com> (https://github.com/lkcampbell)"


### PR DESCRIPTION
These changes prevent the 3 deprecated warnings that show in the dev console when the extension loads.

I also set the default value to 'true' to enable the white-space when the extension is installed. I noticed that upgrading the extension to the newer method required me to re-enable it unless it's set as default true.
