### PR TITLE
added separate classes for tokens on lines which are entirely whitespace

### DIFF
--- a/main.js
+++ b/main.js
@@ -68,6 +68,7 @@ define(function (require, exports, module) {
         var _appendSpace    = false,
             _isLeading      = true,
             _isTrailing     = false,
+            _isEmptyLine    = false,
             _trailingOffset = null;
         
         return {
@@ -81,11 +82,16 @@ define(function (require, exports, module) {
                 if (stream.sol()) {
                     _isLeading  = true;
                     _isTrailing = false;
+                    _isEmptyLine = false;
                     
                     _trailingOffset = stream.string.length;
                     trailing = stream.string.match(/[ \t]+$/);
                     if (trailing) {
                         _trailingOffset -= trailing[0].length;
+                        // everything is whitespace
+                        if(_trailingOffset == 0) {
+                            _isEmptyLine = true;
+                        }
                     }
                 }
                 
@@ -113,7 +119,7 @@ define(function (require, exports, module) {
                         _appendSpace = !_appendSpace;
                         
                         tokenStyle  += "dk-whitespace-";
-                        tokenStyle  += (_isLeading ? "leading-" : (_isTrailing ? "trailing-" : ""));
+                        tokenStyle  += (_isEmptyLine ? "empty-line-" : (_isLeading ? "leading-" : (_isTrailing ? "trailing-" : "")));
                         tokenStyle  += (ch === " " ? "space" : "tab");
                         tokenStyle  += (_appendSpace ? " " : "");
                         

--- a/main.js
+++ b/main.js
@@ -88,8 +88,8 @@ define(function (require, exports, module) {
                     trailing = stream.string.match(/[ \t]+$/);
                     if (trailing) {
                         _trailingOffset -= trailing[0].length;
-                        // everything is whitespace
-                        if(_trailingOffset == 0) {
+                        // Everything is whitespace
+                        if (_trailingOffset === 0) {
                             _isEmptyLine = true;
                         }
                     }

--- a/main.less
+++ b/main.less
@@ -23,7 +23,7 @@
  */
 
 .CodeMirror {
-    .cm-dk-whitespace-space, .cm-dk-whitespace-tab, .cm-dk-whitespace-leading-space, .cm-dk-whitespace-leading-tab, .cm-dk-whitespace-trailing-space, .cm-dk-whitespace-trailing-tab {
+    .cm-dk-whitespace-space, .cm-dk-whitespace-tab, .cm-dk-whitespace-leading-space, .cm-dk-whitespace-leading-tab, .cm-dk-whitespace-trailing-space, .cm-dk-whitespace-trailing-tab, .cm-dk-whitespace-empty-line-space, .cm-dk-whitespace-empty-line-tab {
         position: relative;
         &:before {
             content: "";
@@ -35,7 +35,7 @@
             height: 0.2ex;
         }
     }
-    .cm-dk-whitespace-space:before, .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-trailing-space:before {
+    .cm-dk-whitespace-space:before, .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-empty-line-space:before {
         left: 50%;
         width:        0.2ex;
         margin-left: -0.1ex;
@@ -43,7 +43,7 @@
         min-width:  2px;
         min-height: 2px;
     }
-    .cm-dk-whitespace-tab:before, .cm-dk-whitespace-leading-tab:before, .cm-dk-whitespace-trailing-tab:before {
+    .cm-dk-whitespace-tab:before, .cm-dk-whitespace-leading-tab:before, .cm-dk-whitespace-trailing-tab:before, .cm-dk-whitespace-empty-line-tab:before {
         left: 0.2ex;
         right: 0.2ex;
 
@@ -57,6 +57,9 @@
         background-color: #ccc;
     }
     .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-trailing-tab:before {
+        background-color: red;
+    }
+    .cm-dk-whitespace-empty-line-tab:before, .cm-dk-whitespace-empty-line-space:before {
         background-color: red;
     }
 }

--- a/main.less
+++ b/main.less
@@ -60,6 +60,6 @@
         background-color: red;
     }
     .cm-dk-whitespace-empty-line-tab:before, .cm-dk-whitespace-empty-line-space:before {
-        background-color: red;
+        background-color: #ccc;
     }
 }


### PR DESCRIPTION
I realised that tokens in lines which are 100% whitespace were being labelled as leading, whereas technically they are both trailing AND leading (or neither I guess).

I wanted to highlight these lines differently, but there was no way to do so, so I added a couple of new classes to allow people to distinguish them if they want (`cm-dk-whitespace-empty-line-tab` and `cm-dk-whitespace-empty-line-space`)

I have set them to the same style as trailing whitespace in this PR, but you may want to change to the leading style to match existing behaviour, whatever you think is best.