### PR TITLE
Changed whitespace and tab color

### DIFF
--- a/main.less
+++ b/main.less
@@ -51,12 +51,12 @@
         min-height: 1px;
     }
     .cm-dk-whitespace-space:before, .cm-dk-whitespace-tab:before {
-        background-color: #CCC;
+        background-color: #666;
     }
     .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-leading-tab:before {
-        background-color: #CCC;
+        background-color: #666;
     }
     .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-trailing-tab:before {
-        background-color: red;
+        background-color: #666;
     }
 }

--- a/main.less
+++ b/main.less
@@ -51,10 +51,10 @@
         min-height: 1px;
     }
     .cm-dk-whitespace-space:before, .cm-dk-whitespace-tab:before {
-        background-color: #666666;
+        background-color: #666;
     }
     .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-leading-tab:before {
-        background-color: #666666;
+        background-color: #666;
     }
     .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-trailing-tab:before {
         background-color: red;

--- a/main.less
+++ b/main.less
@@ -51,10 +51,10 @@
         min-height: 1px;
     }
     .cm-dk-whitespace-space:before, .cm-dk-whitespace-tab:before {
-        background-color: #666;
+        background-color: #CCC;
     }
     .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-leading-tab:before {
-        background-color: #666;
+        background-color: #CCC;
     }
     .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-trailing-tab:before {
         background-color: red;

--- a/main.less
+++ b/main.less
@@ -51,10 +51,10 @@
         min-height: 1px;
     }
     .cm-dk-whitespace-space:before, .cm-dk-whitespace-tab:before {
-        background-color: #ccc;
+        background-color: #666666;
     }
     .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-leading-tab:before {
-        background-color: #ccc;
+        background-color: #666666;
     }
     .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-trailing-tab:before {
         background-color: red;


### PR DESCRIPTION
Changed whitespace and tab color given that in high contrast themes these colors were to strong. Although not perfect for low contrast, I think the differences are now smaller.

![changes](https://cloud.githubusercontent.com/assets/8046519/3496959/491b1270-05e7-11e4-931c-36d9dc684267.jpg)