### PR TITLE
User-configurable whitespace

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,7 +69,8 @@ define(function (require, exports, module) {
     var _preferences,
         _command,
         _styleTag,
-        _styleInline;
+        _styleInline,
+        _styleInlineTemplate;
 
     
     // --- Functionality ---
@@ -152,15 +153,10 @@ define(function (require, exports, module) {
     
     /**
      * Apply the whitespace colors.
-     * This does not overwrite styles already defined by a theme.
+     * This does NOT overwrite styles already defined by a theme.
      */
     function _applyColors() {
-        // Compile the CSS from the template
-        var template = _.template(stylesTemplate),
-            compiled = template(_preferences.get("colors"));
-
-        // Update the styling with the changes
-        _styleInline.text(compiled);
+        _styleInline.text(_styleInlineTemplate(_preferences.get("colors")));
     }
 
     function updateEditorViaOverlay(editor) {
@@ -205,7 +201,7 @@ define(function (require, exports, module) {
         }
     }
 
-    function onCheckedStateChange(e) {
+    function onCheckedStateChange() {
         _preferences.set("checked", _command.getChecked());
         _preferences.set("colors", _preferences.get("colors"));
         updateEditors();
@@ -246,6 +242,7 @@ define(function (require, exports, module) {
             _styleTag = node;
         });
         _styleInline = $(ExtensionUtils.addEmbeddedStyleSheet(""));
+        _styleInlineTemplate = _.template(stylesTemplate);
         _applyColors();
     }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     ],
     "license": "MIT",
     "engines": {
-        "brackets": ">=0.38.0"
+        "brackets": ">=0.42.0"
     }
 }

--- a/styles/main.less
+++ b/styles/main.less
@@ -50,16 +50,4 @@
         min-width:  2px;
         min-height: 1px;
     }
-    .cm-dk-whitespace-space:before, .cm-dk-whitespace-tab:before {
-        background-color: #ccc;
-    }
-    .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-leading-tab:before {
-        background-color: #ccc;
-    }
-    .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-trailing-tab:before {
-        background-color: red;
-    }
-    .cm-dk-whitespace-empty-line-tab:before, .cm-dk-whitespace-empty-line-space:before {
-        background-color: #ccc;
-    }
 }

--- a/styles/whitespace-colors-css.tmpl
+++ b/styles/whitespace-colors-css.tmpl
@@ -1,0 +1,23 @@
+/*
+ * dkehrig.show-whitespace whitespace colors template.
+ */
+
+/* Light theme */
+.CodeMirror .cm-dk-whitespace-space:before,
+.CodeMirror .cm-dk-whitespace-tab:before { background-color: <%= light.whitespace %>; }
+.CodeMirror .cm-dk-whitespace-leading-space:before,
+.CodeMirror .cm-dk-whitespace-leading-tab:before { background-color: <%= light.leading %>; }
+.CodeMirror .cm-dk-whitespace-empty-line-tab:before,
+.CodeMirror .cm-dk-whitespace-empty-line-space:before { background-color: <%= light.empty %>; }
+.CodeMirror .cm-dk-whitespace-trailing-space:before,
+.CodeMirror .cm-dk-whitespace-trailing-tab:before { background-color: <%= light.trailing %>; }
+
+/* Dark theme */
+.dark .CodeMirror .cm-dk-whitespace-space:before,
+.dark .CodeMirror .cm-dk-whitespace-tab:before { background-color: <%= dark.whitespace %>; }
+.dark .CodeMirror .cm-dk-whitespace-leading-space:before,
+.dark .CodeMirror .cm-dk-whitespace-leading-tab:before { background-color: <%= dark.leading %>; }
+.dark .CodeMirror .cm-dk-whitespace-empty-line-tab:before,
+.dark .CodeMirror .cm-dk-whitespace-empty-line-space:before { background-color: <%= dark.empty %>; }
+.dark .CodeMirror .cm-dk-whitespace-trailing-space:before,
+.dark .CodeMirror .cm-dk-whitespace-trailing-tab:before { background-color: <%= dark.trailing %>; }


### PR DESCRIPTION
For #26. Adds a preference so whitespace can be recolored by the user. Supersedes #30.

### Implementation preferences layout ###

```json
"denniskehrig.ShowWhitespace.colors": {
    "light": {
        "empty": "#ccc",
        "leading": "#ccc",
        "trailing": "#ff0000",
        "whitespace": "#ccc"
    },
    "dark": {
        "empty": "#686963",
        "leading": "#686963",
        "trailing": "#ff0000",
        "whitespace": "#686963"
    }
}
```
 
### Notes ###
* **Requires Brackets v0.42 and higher**
* Does _not_ overwrite colors defined by themes. This can be both good and bad.
- [x] Need good default values for the built-in Brackets dark theme.