### PR TITLE
Update events to use v1.1 system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## v2.1.0 - Unreleased
 
-* **Requires Brackets v0.42 and higher**
+* **Requires Brackets 1.1 or higher**
 * Remove CodeMirror 2 support
 * Add new `cm-dk-whitespace-empty-line-space` and `cm-dk-whitespace-empty-line-tab` tokens for recoloring blank lines
 * Add user-configurable colors using the Brackets preferences system
 * Add support for built-in Brackets dark theme
 * Add localization support
+* Update events listeners to use event system introduced in Brackets 1.1
 * Minor code cleanup
 
 ## v2.0.1 - 2014/5/59

--- a/main.js
+++ b/main.js
@@ -213,7 +213,7 @@ define(function (require, exports, module) {
             _command._commandFn = onCommandExecuted;
         }
 
-        $(_command).on("checkedStateChange", onCheckedStateChange);
+        _command.on("checkedStateChange", onCheckedStateChange);
         
         // Apply preferences
         _command.setChecked(_preferences.get("checked"));
@@ -221,7 +221,7 @@ define(function (require, exports, module) {
 
     function unloadCommand() {
         _command.setChecked(false);
-        $(_command).off("checkedStateChange", onCheckedStateChange);
+        _command.off("checkedStateChange", onCheckedStateChange);
         _command._commandFn = null;
     }
 
@@ -236,11 +236,11 @@ define(function (require, exports, module) {
     
     
     function loadEditorSync() {
-        $(EditorManager).on("activeEditorChange", onActiveEditorChange);
+        EditorManager.on("activeEditorChange", onActiveEditorChange);
     }
 
     function unloadEditorSync() {
-        $(EditorManager).off("activeEditorChange", onActiveEditorChange);
+        EditorManager.off("activeEditorChange", onActiveEditorChange);
     }
 
     

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     ],
     "license": "MIT",
     "engines": {
-        "brackets": ">=0.38.0"
+        "brackets": ">=1.1.0"
     }
 }


### PR DESCRIPTION
Update events system to use the new event system introduced in Brackets v1.1 (adobe/brackets#9918).

This is invoked out of adobe/brackets#10415, which adds more verbose deprecation warnings for the jQuery shim, through which this extension is affected.