### PR TITLE
Rename `checked` preference to `enabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add user-configurable colors using the Brackets preferences system
 * Add support for built-in Brackets dark theme
 * Add localization support
+* Rename `checked` preference to `enabled`
 * Update events listeners to use event system introduced in Brackets 1.1
 * Minor code cleanup
 


### PR DESCRIPTION
This better reflects the preference's actual purpose. Also a bit of cleanup and making the `enabled` pref react to editing (AKA it is now listened for).