### PR TITLE
Add token for non breaking space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## v2.1.0 - Unreleased
 
 * **Requires Brackets 1.1 or higher**
-* Remove CodeMirror 2 support
 * Add new `cm-dk-whitespace-empty-line-space` and `cm-dk-whitespace-empty-line-tab` tokens for recoloring blank lines
+* Add new `cm-dk-whitespace-*-nonbrk-space` tokens for recoloring non-breaking spaces
 * Add user-configurable colors using the Brackets preferences system
 * Add support for built-in Brackets dark theme
 * Add localization support
+* Remove CodeMirror 2 support
 * Rename `checked` preference to `enabled`
 * Update events listeners to use event system introduced in Brackets 1.1
 * Minor code cleanup

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This extension uses [CodeMirror](http://codemirror.net/) overlays to construct a
 * `.cm-dk-whitespace-leading-space`: Whitespace that makes up any indentation
 * `.cm-dk-whitespace-empty-line-space`: Any lines that consist solely of whitespace
 * `.cm-dk-whitespace-trailing-space`: Whitespace at the end of a line after any characters
+* `.cm-dk-whitespace-*-nonbrk-space`: A [non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space), which can be classed with any location (such as `.cm-dk-whitespace-empty-line-nonbrk-space`). This is the only class that does not have a tab counterpart.
 
 The primary extension styling is defined in `styles/main.less`, which is compiled into CSS, while whitespace colors are defined in Brackets preferences and rendered into `styles/whitespace-colors-css.tmpl`. Both files are then loaded into Brackets on startup.
 

--- a/main.js
+++ b/main.js
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
                     _isEmptyLine = false;
                     
                     _trailingOffset = stream.string.length;
-                    trailing = stream.string.match(/[ \t]+$/);
+                    trailing = stream.string.match(/[ \t\u00A0]+$/);
                     if (trailing) {
                         _trailingOffset -= trailing[0].length;
                         // Everything is whitespace
@@ -115,7 +115,7 @@ define(function (require, exports, module) {
                 // Peek ahead one character at a time
                 // Wrapping the assignment in a Boolean makes JSLint happy
                 while (Boolean(ch = stream.peek())) {
-                    if (ch === " " || ch === "\t") {
+                    if (ch === " " || ch === "\t" || ch === "\xA0") {
                         if (ateCode) {
                             // Return now to mark all code seen so far as not necessary to highlight
                             return null;
@@ -137,7 +137,7 @@ define(function (require, exports, module) {
                         
                         tokenStyle  += "dk-whitespace-";
                         tokenStyle  += (_isEmptyLine ? "empty-line-" : (_isLeading ? "leading-" : (_isTrailing ? "trailing-" : "")));
-                        tokenStyle  += (ch === " " ? "space" : "tab");
+                        tokenStyle  += (ch === " " ? "space" : (ch === "\xA0" ? "nonbrk-space" : "tab"));
                         tokenStyle  += (_appendSpace ? " " : "");
                         
                         return tokenStyle;

--- a/styles/main.less
+++ b/styles/main.less
@@ -23,7 +23,18 @@
  */
 
 .CodeMirror {
-    .cm-dk-whitespace-space, .cm-dk-whitespace-tab, .cm-dk-whitespace-leading-space, .cm-dk-whitespace-leading-tab, .cm-dk-whitespace-trailing-space, .cm-dk-whitespace-trailing-tab, .cm-dk-whitespace-empty-line-space, .cm-dk-whitespace-empty-line-tab {
+    .cm-dk-whitespace-space,
+    .cm-dk-whitespace-nonbrk-space,
+    .cm-dk-whitespace-tab,
+    .cm-dk-whitespace-leading-space,
+    .cm-dk-whitespace-leading-nonbrk-space,
+    .cm-dk-whitespace-leading-tab,
+    .cm-dk-whitespace-trailing-space,
+    .cm-dk-whitespace-trailing-nonbrk-space,
+    .cm-dk-whitespace-trailing-tab,
+    .cm-dk-whitespace-empty-line-space,
+    .cm-dk-whitespace-empty-line-nonbrk-space,
+    .cm-dk-whitespace-empty-line-tab {
         position: relative;
         &:before {
             content: "";
@@ -35,7 +46,15 @@
             height: 0.2ex;
         }
     }
-    .cm-dk-whitespace-space:before, .cm-dk-whitespace-leading-space:before, .cm-dk-whitespace-trailing-space:before, .cm-dk-whitespace-empty-line-space:before {
+
+    .cm-dk-whitespace-space:before,
+    .cm-dk-whitespace-nonbrk-space:before,
+    .cm-dk-whitespace-leading-space:before,
+    .cm-dk-whitespace-leading-nonbrk-space:before,
+    .cm-dk-whitespace-trailing-space:before,
+    .cm-dk-whitespace-trailing-nonbrk-space:before,
+    .cm-dk-whitespace-empty-line-space:before,
+    .cm-dk-whitespace-empty-line-nonbrk-space:before {
         left: 50%;
         width:        0.2ex;
         margin-left: -0.1ex;
@@ -43,7 +62,11 @@
         min-width:  2px;
         min-height: 2px;
     }
-    .cm-dk-whitespace-tab:before, .cm-dk-whitespace-leading-tab:before, .cm-dk-whitespace-trailing-tab:before, .cm-dk-whitespace-empty-line-tab:before {
+
+    .cm-dk-whitespace-tab:before,
+    .cm-dk-whitespace-leading-tab:before,
+    .cm-dk-whitespace-trailing-tab:before,
+    .cm-dk-whitespace-empty-line-tab:before {
         left: 0.2ex;
         right: 0.2ex;
 

--- a/styles/whitespace-colors-css.tmpl
+++ b/styles/whitespace-colors-css.tmpl
@@ -11,6 +11,10 @@
 .CodeMirror .cm-dk-whitespace-empty-line-tab:before { background-color: <%= light.empty %>; }
 .CodeMirror .cm-dk-whitespace-trailing-space:before,
 .CodeMirror .cm-dk-whitespace-trailing-tab:before { background-color: <%= light.trailing %>; }
+.CodeMirror .cm-dk-whitespace-nonbrk-space:before,
+.CodeMirror .cm-dk-whitespace-leading-nonbrk-space:before,
+.CodeMirror .cm-dk-whitespace-empty-line-nonbrk-space:before,
+.CodeMirror .cm-dk-whitespace-trailing-nonbrk-space:before { background-color: <%= light.trailing %>; }
 
 /* Dark theme */
 .dark .CodeMirror .cm-dk-whitespace-space:before,
@@ -21,3 +25,7 @@
 .dark .CodeMirror .cm-dk-whitespace-empty-line-tab:before { background-color: <%= dark.empty %>; }
 .dark .CodeMirror .cm-dk-whitespace-trailing-space:before,
 .dark .CodeMirror .cm-dk-whitespace-trailing-tab:before { background-color: <%= dark.trailing %>; }
+.dark .CodeMirror .cm-dk-whitespace-nonbrk-space:before,
+.dark .CodeMirror .cm-dk-whitespace-leading-nonbrk-space:before,
+.dark .CodeMirror .cm-dk-whitespace-empty-line-nonbrk-space:before,
+.dark .CodeMirror .cm-dk-whitespace-trailing-nonbrk-space:before { background-color: <%= dark.trailing %>; }


### PR DESCRIPTION
I discovered non-breaking spaces are not classed, so they never receive whitespace highlighting. Because software can choke on non-breaking spaces, I've highlighted it in the same style as trailing whitespace to make it more visible and serve as a warning that maybe it should be replaced with a normal space.

@MiguelCastillo I know I keep tagging you for code reviews, so if you can't look over this (which is fine), I can ask someone else (maybe @MarcelGerber?)