### PR TITLE
Correct keyboard shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-Activate using `View > Show Whitespace` or by using the shortcut `Ctrl-Shift-W` (`Command-Shift-W` on Mac OS X). The extension state is remembered across Brackets launches. Whitespace in all editor windows are visualized, including inline editors.
+Activate using `View > Show Whitespace` or by using the shortcut `Ctrl-Alt-W` (`Command-Shift-W` on Mac OS X). The extension state is remembered across Brackets launches. Whitespace in all editor windows are visualized, including inline editors.
 
 ## Technical Details
 


### PR DESCRIPTION
A colleague uses brackets-show-whitespace on Windows, he noticed that the keyboard shortcut to toggle whitespace display is Ctrl-Alt-W, not Ctrl-Shift-W as mentioned in the fine docs. Here is a pull request to correct the docs.

Thank you.